### PR TITLE
feat(dashy): Override container command and args

### DIFF
--- a/charts/dashy/templates/deployment.yaml
+++ b/charts/dashy/templates/deployment.yaml
@@ -38,6 +38,12 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.command }}
+          command: {{ .Values.command }}
+          {{- end }}
+          {{- if .Values.args }}
+          args: {{ .Values.args }}
+          {{- end }}
           {{- if .Values.env}}
           envFrom:
           {{- if not .Values.env.existingSecret }}

--- a/charts/dashy/values.yaml
+++ b/charts/dashy/values.yaml
@@ -10,6 +10,9 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "release-3.1.1"
 
+command: []
+args: []
+
 # Choose deployment strategy type
 strategyType: Recreate
 


### PR DESCRIPTION
This will mainly allow to override `spec.container.args` as the current dashy Dockerfile define CMD as: `[ "yarn", "build-and-start" ]`, causing the app to be rebuild everytime the container start, which is a long task (see #1543)

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Dashy takes a long time to start because the app is rebuild everytime, currently the only way to workaroud this is to fork the image to edit the `CMD` or the chart to edit the `args`.

Issue Number: [#1543](https://github.com/Lissy93/dashy/issues/1543)

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `command` and `args` can be override in the values
- Default behavior stay the same, causing no breaking change

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
